### PR TITLE
BREAKING CHANGE: Simplify Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 prod/
 public
 resources
+.idea

--- a/api/common.go
+++ b/api/common.go
@@ -49,9 +49,9 @@ func buildDataSourcePath(conf *viper.Viper, name string) string {
 //getResourcePath for a gven resource type: ["dashboard", "ds"] it'll return the configured location
 func getResourcePath(conf *viper.Viper, resourceType string) string {
 	if resourceType == "dashboard" {
-		return apphelpers.GetCtxDefaultGrafanaConfig().OutputDashboard
+		return apphelpers.GetCtxDefaultGrafanaConfig().GetDashboardOutput()
 	} else if resourceType == "ds" {
-		return apphelpers.GetCtxDefaultGrafanaConfig().OutputDataSource
+		return apphelpers.GetCtxDefaultGrafanaConfig().GetDataSourceOutput()
 	}
 	return ""
 }

--- a/api/dashboards.go
+++ b/api/dashboards.go
@@ -142,8 +142,7 @@ func (s *DashNGoImpl) ExportDashboards(filters Filter) {
 				log.Printf("Failed to unmarshall file: %s", file)
 				continue
 			}
-
-			elements := strings.Split(file, "/")
+			elements := strings.Split(file, string(os.PathSeparator))
 			if len(elements) >= 2 {
 				folderName = elements[len(elements)-2]
 			}

--- a/api/datasources.go
+++ b/api/datasources.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gosimple/slug"
@@ -85,7 +86,7 @@ func (s *DashNGoImpl) ExportDataSources(filter Filter) []string {
 		fmt.Fprint(os.Stderr, err)
 	}
 	for _, file := range filesInDir {
-		fileLocation := fmt.Sprintf("%s/%s", getResourcePath(s.configRef, "ds"), file.Name())
+		fileLocation := filepath.Join(getResourcePath(s.configRef, "ds"), file.Name())
 		if strings.HasSuffix(file.Name(), ".json") {
 			if rawDS, err = ioutil.ReadFile(fileLocation); err != nil {
 				fmt.Fprint(os.Stderr, err)

--- a/apphelpers/contextHelper.go
+++ b/apphelpers/contextHelper.go
@@ -81,12 +81,8 @@ func NewContext(name string) {
 			Prompt: &survey.Input{Message: "What is the Grafana URL include http(s)?"},
 		},
 		{
-			Name:   "OutputDashboard",
-			Prompt: &survey.Input{Message: "Dashboard destination folder?"},
-		},
-		{
-			Name:   "OutputDataSource",
-			Prompt: &survey.Input{Message: "Datasource destination folder?"},
+			Name:   "OutputPath",
+			Prompt: &survey.Input{Message: "Destination Folder?"},
 		},
 	}
 

--- a/conf/importer-example.yml
+++ b/conf/importer-example.yml
@@ -2,12 +2,11 @@ context_name: qa
 
 contexts:
   testing:
-    dashboards_output: testing_data/dashboards
+    output_path: testing_data
     datasources:
       default:
         user: user
         password: password
-    datasources_output: testing_data/datasources
     url: http://grafana:3000
     user_name: admin
     password: admin
@@ -16,7 +15,7 @@ contexts:
       - Other
 
   production:
-    dashboards_output: prod/dashboards
+    output_path: prod
     datasources:
       complex name:
         password: secret
@@ -27,7 +26,6 @@ contexts:
       ds_name:
         password: secret
         user: abcd
-    datasources_output: prod/datasources
     url: https://grafana.com
     user_name: admin
     password: admin
@@ -35,7 +33,7 @@ contexts:
     watched:
       - General
   qa:
-    dashboards_output: qa/dashboards
+    output_path: qa
     token: <CHANGEME>
     datasources:
       complex name:
@@ -47,7 +45,6 @@ contexts:
       ds_name:
         password: secret
         user: abcd
-    datasources_output: qa/datasources
     url: https://staging.grafana.com
     organization: your-org
     watched:

--- a/config/config_model.go
+++ b/config/config_model.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -17,8 +18,15 @@ type GrafanaConfig struct {
 	MonitoredFolders   []string                      `yaml:"watched"`
 	DefaultDataSource  *GrafanaDataSource            `yaml:"-"`
 	DataSourceSettings map[string]*GrafanaDataSource `yaml:"datasources"`
-	OutputDashboard    string                        `yaml:"dashboards_output"`
-	OutputDataSource   string                        `yaml:"datasources_output"`
+	OutputPath         string                        `yaml:"output_path"`
+}
+
+func (s *GrafanaConfig) GetDashboardOutput() string {
+	return path.Join(s.OutputPath, "dashboards")
+}
+
+func (s *GrafanaConfig) GetDataSourceOutput() string {
+	return path.Join(s.OutputPath, "datasources")
 }
 
 //GetMonitoredFolders return a list of the monitored folders alternatively returns the "General" folder.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,8 +28,8 @@ func validateGrafanaQA(t *testing.T, grafana *config.GrafanaConfig) {
 	folders := grafana.GetMonitoredFolders()
 	assert.True(t, funk.Contains(folders, "Folder1"))
 	assert.True(t, funk.Contains(folders, "Folder2"))
-	assert.Equal(t, "qa/datasources", grafana.OutputDataSource)
-	assert.Equal(t, "qa/dashboards", grafana.OutputDashboard)
+	assert.Equal(t, "qa/datasources", grafana.GetDataSourceOutput())
+	assert.Equal(t, "qa/dashboards", grafana.GetDashboardOutput())
 	dsSettings := grafana.DataSourceSettings
 	defaultSettings := dsSettings["default"]
 	assert.Equal(t, "user", defaultSettings.User)

--- a/documentation/content/docs/configuration.md
+++ b/documentation/content/docs/configuration.md
@@ -25,7 +25,7 @@ contexts:
   main:
     url: https://grafana.example.org
     token: "<<Grafana API Token>>"
-    dashboards_output: "dashboards"
+    output_path: "myFolder"
     watched:
       - Example
 
@@ -45,7 +45,7 @@ contexts:
     url: https://grafana.example.org
     user_name: <your username>
     password: <your password>
-    dashboards_output: "dashboards"
+    output_path: "myFolder"
     watched:
       - Example
 


### PR DESCRIPTION
Fixes #42

ChangeLog:
  - This changes the structure of the configuration so it's a breaking
    change from previous behavior.
  - Removes the configurable destination of datasources/dashboard instead setting up a basepath where all entities are read/written to.
  - Updated the documentation accordingly.
  - Updating new CTX wizard to reflect new changes.