### PR TITLE
support nested dashboard-folders for backup-download

### DIFF
--- a/config/importer-example.yml
+++ b/config/importer-example.yml
@@ -59,7 +59,7 @@ contexts:
     password: admin
     filter_override:
       ignore_dashboard_filters: false # When set to true all Watched filtered folders will be ignored and ALL folders will be acted on
-      download_nested_dashboard_folders: false # If true, the dashboard-download will create the proper nesting of (sub)folders - WARN: not (yet) compatible with the upload-feature!!!
+    download_nested_dashboard_folders: false # If true, the dashboard-download will create the proper nesting of (sub)folders - WARN: not (yet) compatible with the upload-feature!!!
     watched:
       - General
       - Other

--- a/config/importer-example.yml
+++ b/config/importer-example.yml
@@ -59,6 +59,7 @@ contexts:
     password: admin
     filter_override:
       ignore_dashboard_filters: false # When set to true all Watched filtered folders will be ignored and ALL folders will be acted on
+      download_nested_dashboard_folders: false # If true, the dashboard-download will create the proper nesting of (sub)folders - WARN: not (yet) compatible with the upload-feature!!!
     watched:
       - General
       - Other

--- a/internal/config/connection_config.go
+++ b/internal/config/connection_config.go
@@ -56,8 +56,7 @@ type MatchingRule struct {
 
 // FilterOverrides model wraps filter overrides for grafana
 type FilterOverrides struct {
-	IgnoreDashboardFilters         bool `yaml:"ignore_dashboard_filters"`
-	DownloadNestedDashboardFolders bool `yaml:"download_nested_dashboard_folders"`
+	IgnoreDashboardFilters bool `yaml:"ignore_dashboard_filters"`
 }
 
 // ConnectionFilters model wraps connection filters for grafana

--- a/internal/config/connection_config.go
+++ b/internal/config/connection_config.go
@@ -56,7 +56,8 @@ type MatchingRule struct {
 
 // FilterOverrides model wraps filter overrides for grafana
 type FilterOverrides struct {
-	IgnoreDashboardFilters bool `yaml:"ignore_dashboard_filters"`
+	IgnoreDashboardFilters         bool `yaml:"ignore_dashboard_filters"`
+	DownloadNestedDashboardFolders bool `yaml:"download_nested_dashboard_folders"`
 }
 
 // ConnectionFilters model wraps connection filters for grafana

--- a/internal/config/grafana_config.go
+++ b/internal/config/grafana_config.go
@@ -2,20 +2,21 @@ package config
 
 // GrafanaConfig model wraps auth and watched list for grafana
 type GrafanaConfig struct {
-	Storage                  string                `mapstructure:"storage" yaml:"storage"`
-	grafanaAdminEnabled      bool                  `mapstructure:"-" yaml:"-"`
-	EnterpriseSupport        bool                  `mapstructure:"enterprise_support" yaml:"enterprise_support"`
-	URL                      string                `mapstructure:"url" yaml:"url"`
-	APIToken                 string                `mapstructure:"token" yaml:"token"`
-	UserName                 string                `mapstructure:"user_name" yaml:"user_name"`
-	Password                 string                `mapstructure:"password" yaml:"password"`
-	OrganizationName         string                `mapstructure:"organization_name" yaml:"organization_name"`
-	MonitoredFoldersOverride []MonitoredOrgFolders `mapstructure:"watched_folders_override" yaml:"watched_folders_override"`
-	MonitoredFolders         []string              `mapstructure:"watched" yaml:"watched"`
-	ConnectionSettings       *ConnectionSettings   `mapstructure:"connections" yaml:"connections"`
-	UserSettings             *UserSettings         `mapstructure:"user" yaml:"user"`
-	FilterOverrides          *FilterOverrides      `mapstructure:"filter_override" yaml:"filter_override"`
-	OutputPath               string                `mapstructure:"output_path" yaml:"output_path"`
+	Storage                        string                `mapstructure:"storage" yaml:"storage"`
+	grafanaAdminEnabled            bool                  `mapstructure:"-" yaml:"-"`
+	EnterpriseSupport              bool                  `mapstructure:"enterprise_support" yaml:"enterprise_support"`
+	URL                            string                `mapstructure:"url" yaml:"url"`
+	APIToken                       string                `mapstructure:"token" yaml:"token"`
+	UserName                       string                `mapstructure:"user_name" yaml:"user_name"`
+	Password                       string                `mapstructure:"password" yaml:"password"`
+	OrganizationName               string                `mapstructure:"organization_name" yaml:"organization_name"`
+	MonitoredFoldersOverride       []MonitoredOrgFolders `mapstructure:"watched_folders_override" yaml:"watched_folders_override"`
+	MonitoredFolders               []string              `mapstructure:"watched" yaml:"watched"`
+	ConnectionSettings             *ConnectionSettings   `mapstructure:"connections" yaml:"connections"`
+	UserSettings                   *UserSettings         `mapstructure:"user" yaml:"user"`
+	FilterOverrides                *FilterOverrides      `mapstructure:"filter_override" yaml:"filter_override"`
+	OutputPath                     string                `mapstructure:"output_path" yaml:"output_path"`
+	DownloadNestedDashboardFolders bool                  `mapstructure:"download_nested_dashboard_folders" yaml:"download_nested_dashboard_folders"`
 }
 
 type MonitoredOrgFolders struct {

--- a/internal/service/common.go
+++ b/internal/service/common.go
@@ -59,11 +59,7 @@ func BuildResourceFolder(folderName string, resourceType config.ResourceType) st
 	if resourceType == config.DashboardResource && folderName == "" {
 		folderName = DefaultFolderName
 	}
-	strSeperator := string(os.PathSeparator)
 
-	if strings.Contains(folderName, strSeperator) {
-		folderName = strings.ReplaceAll(folderName, strSeperator, fmt.Sprintf("//%s", strSeperator))
-	}
 	v := fmt.Sprintf("%s/%s", config.Config().GetDefaultGrafanaConfig().GetPath(resourceType), folderName)
 	tools.CreateDestinationPath(v)
 	return v

--- a/internal/service/dashboards.go
+++ b/internal/service/dashboards.go
@@ -216,7 +216,7 @@ func (s *DashNGoImpl) listDashboardsAndFolders(filterReq filters.Filter, allType
 			}
 			searchParams.Limit = tools.PtrOf(limit)
 			searchParams.Page = tools.PtrOf(page)
-			if allTypes == false {
+			if !allTypes {
 				searchParams.Type = tools.PtrOf(searchTypeDashboard)
 			}
 
@@ -263,7 +263,7 @@ func (s *DashNGoImpl) listDashboardsAndFolders(filterReq filters.Filter, allType
 			continue
 		}
 		validUid = filterReq.GetFilter(filters.DashFilter) == "" || link.Slug == filterReq.GetFilter(filters.DashFilter)
-		if link.FolderID == 0 && link.Type == "dash-db" {
+		if link.FolderID == 0 && string(link.Type) == searchTypeDashboard {
 			link.FolderTitle = DefaultFolderName
 		}
 
@@ -290,12 +290,12 @@ func (s *DashNGoImpl) DownloadDashboards(filter filters.Filter) []string {
 		metaData   *dashboards.GetDashboardByUIDOK
 	)
 
-	var nesting = config.Config().GetDefaultGrafanaConfig().GetFilterOverrides().DownloadNestedDashboardFolders
+	var nesting = config.Config().GetDefaultGrafanaConfig().DownloadNestedDashboardFolders
 	slog.Info("Downloading dashboards with ", "nested", nesting)
 	boardLinks = s.listDashboardsAndFolders(filter, nesting)
 	var boards []string
 	for _, link := range boardLinks {
-		if link.Type != "dash-db" {
+		if string(link.Type) != searchTypeDashboard {
 			slog.Debug("Ignoring dashboard-folder", "folder", link.Title)
 			continue
 		}

--- a/internal/service/dashboards_test.go
+++ b/internal/service/dashboards_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"github.com/esnet/gdg/internal/config"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func createDummyDashboard(dbName string, dbId int64, parent *models.Hit) *models.Hit {
+	return &models.Hit{
+		FolderID:    parent.ID,
+		FolderTitle: parent.Title,
+		FolderUID:   parent.UID,
+		Title:       dbName,
+		ID:          dbId,
+		Type:        "dash-db",
+	}
+}
+
+func createDummyFolder(folderTitle string, folderId int64, folderUid string, parent *models.Hit) *models.Hit {
+	var parentId int64 = 0
+	var parentTitle = ""
+	var parentUID = ""
+	if parent != nil {
+		parentId = parent.ID
+		parentTitle = parent.Title
+		parentUID = parent.UID
+	}
+	return &models.Hit{
+		FolderID:    parentId,
+		FolderTitle: parentTitle,
+		FolderUID:   parentUID,
+		Title:       folderTitle,
+		ID:          folderId,
+		UID:         folderUid,
+		Type:        "dash-db",
+	}
+}
+
+func TestHitBehaviour(t *testing.T) {
+	rootFolder := createDummyFolder("root", 21, "x21", nil)
+
+	assert.Equal(t, "", rootFolder.FolderUID)
+}
+
+func TestBuildDashboardFileName(t *testing.T) {
+	expectedResult := "test/data/org_main-org/dashboards/root/narf/zort.json"
+	expectedResultOther := "test/data/org_main-org/dashboards/root/poit.json"
+
+	rootFolder := createDummyFolder("root", 21, "x21", nil)
+	subFolder := createDummyFolder("narf", 23, "x23", rootFolder)
+	dummyDashboard := createDummyDashboard("ZORT", 42, subFolder)
+	dummyDashboardOther := createDummyDashboard("POIT", 7, rootFolder)
+
+	boardList := make([]*models.Hit, 0)
+	boardList = append(boardList, rootFolder)
+	boardList = append(boardList, dummyDashboardOther)
+	boardList = append(boardList, subFolder)
+	boardList = append(boardList, dummyDashboard)
+
+	config.InitGdgConfig("testing.yml", "'")
+	result := buildDashboardFileName(dummyDashboard, "zort", boardList)
+	resultOther := buildDashboardFileName(dummyDashboardOther, "poit", boardList)
+
+	assert.NotNil(t, result)
+	assert.Equal(t, expectedResult, result)
+
+	assert.NotNil(t, resultOther)
+	assert.Equal(t, expectedResultOther, resultOther)
+}

--- a/internal/service/dashboards_test.go
+++ b/internal/service/dashboards_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/esnet/gdg/internal/config"
+	"github.com/gosimple/slug"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -45,8 +46,11 @@ func TestHitBehaviour(t *testing.T) {
 }
 
 func TestBuildDashboardFileName(t *testing.T) {
-	expectedResult := "test/data/org_main-org/dashboards/root/narf/zort.json"
-	expectedResultOther := "test/data/org_main-org/dashboards/root/poit.json"
+	config.InitGdgConfig("testing.yml", "'")
+	orgName := slug.Make(config.Config().GetDefaultGrafanaConfig().GetOrganizationName())
+
+	expectedResult := "test/data/org_" + orgName + "/dashboards/root/narf/zort.json"
+	expectedResultOther := "test/data/org_" + orgName + "/dashboards/root/poit.json"
 
 	rootFolder := createDummyFolder("root", 21, "x21", nil)
 	subFolder := createDummyFolder("narf", 23, "x23", rootFolder)
@@ -59,7 +63,6 @@ func TestBuildDashboardFileName(t *testing.T) {
 	boardList = append(boardList, subFolder)
 	boardList = append(boardList, dummyDashboard)
 
-	config.InitGdgConfig("testing.yml", "'")
 	result := buildDashboardFileName(dummyDashboard, "zort", boardList)
 	resultOther := buildDashboardFileName(dummyDashboardOther, "poit", boardList)
 


### PR DESCRIPTION
**Our use-case**: 
We use gdg only as a backup-tool (no restore).

**The issue**:
A while ago, Grafana introduced the feature of nested sub-folders for dashboards.
So far gdg would download those folders, but all on the same level. This has (at least) two major problems:
* the connection to the original folder (and in our case "team") is lost
* dashboards could overwrite each other, if they as well as the folder they're in, have the same name as those from another folder/team.

**What changed**:
* determine the full path of a dashboard (not just use its parent folder) and use that for the download
* in order to be able to do that: also fetch folders (type `dash-folder`) in the `ListDashboards`-search
  * limit this behavior to the `DownloadDashboards` functionality (if enabled at all)
* added a new config-option in the `filter_override`s to enable this feature/behavior
* added a unit-test, to ensure the download-path is calculated correctly 

_Known Issues_:
* currently only supported in DownloadDashboards
* might interfere with other features like UploadDashboards if used in combination (as those currently don't support nested folders - and explicitly so)