### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,7 +112,9 @@ homebrew_casks:
     homepage: https://software.es.net/gdg
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     description: Grafana Dash-n-Grab (GDG) -- Dashboard/DataSource Manager for grafana supporting backup/restore to local filesystem, s3, gcs, azure, and other S3 compatible storage engines.
-    directory: Formula
+    directory: Casks
+    conflicts:
+      - formula: gdg
     repository:
       owner: esnet
       name: homebrew-gdg
@@ -121,6 +123,12 @@ homebrew_casks:
     commit_author:
       name: GDG ESNet
       email: gdg@es.net
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gdg"]
+          end
 
 archives:
   - name_template: >-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ nfpms:
     description: |-
       GDG is a tool used to manage dashboards, connections, organizations and various entities of the Grafana application.
     license: BSD License
-    builds:
+    ids:
       - gdg
       - gdg-generate
     formats:
@@ -107,7 +107,7 @@ dockers:
     dockerfile: "docker/Dockerfile"
 
 
-brews:
+homebrew_casks:
   - name: gdg
     homepage: https://software.es.net/gdg
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
@@ -132,7 +132,7 @@ archives:
     format_overrides:
       - goos: windows
         formats: [ 'zip' ]
-    builds:
+    ids:
       - gdg
       - gdg-generate
     files:


### PR DESCRIPTION
### Community Note
This small PR updates the GoReleaser configuration to resolve the following warnings: 
```
DEPRECATED:  archives.builds  should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
DEPRECATED:  nfpms.builds  should not be used anymore, check https://goreleaser.com/deprecations#nfpmsbuilds for more info
DEPRECATED:  brews  should not be used anymore, check https://goreleaser.com/deprecations#brews for more info
```
Fixed #450.