### PR TITLE
Fix config in FAQ for list all dashboards

### DIFF
--- a/website/content/docs/gdg/faq.md
+++ b/website/content/docs/gdg/faq.md
@@ -23,7 +23,7 @@ PS. if you want to list/import etc all dashboards, you can set the following con
 
 ```yaml
     dashboard_settings:
-      ignore_filters: false # When set to true all Watched filtered folders will be ignored and ALL folders will be acted on
+      ignore_filters: true # When set to true all Watched filtered folders will be ignored and ALL folders will be acted on
 
 ```
 


### PR DESCRIPTION
Fixes an issue in the docs in the FAQ section for getting all dashboards.

The comment says it should be true and from my testing true is the value that works.