### PR TITLE
Fix issue with grafana_config / auth_grafanacloud

### DIFF
--- a/internal/config/domain/grafana_config.go
+++ b/internal/config/domain/grafana_config.go
@@ -156,17 +156,16 @@ func (s *GrafanaConfig) UpdateSecureModel(fn func(string) (string, error)) {
 
 // GetPassword returns the password, respecting environment variable override if set.
 func (s *GrafanaConfig) GetPassword() string {
-	secureAuth := s.getSecureAuth()
-	if secureAuth == nil {
-		return ""
-	}
-	// Backward compatibility to allow Env Override
-	// Get Env Value
-
+	// Check Env Override first, so it works even without a secure auth file
 	envKey := fmt.Sprintf("GDG_CONTEXTS__%s__PASSWORD", strings.ToUpper(s.contextName))
 	val := os.Getenv(envKey)
 	if val != "" {
 		return val
+	}
+
+	secureAuth := s.getSecureAuth()
+	if secureAuth == nil {
+		return ""
 	}
 
 	return secureAuth.Password
@@ -174,16 +173,16 @@ func (s *GrafanaConfig) GetPassword() string {
 
 // GetAPIToken returns the API token, checking for an environment variable override before falling back to stored credentials.
 func (s *GrafanaConfig) GetAPIToken() string {
-	secureAuth := s.getSecureAuth()
-	if secureAuth == nil {
-		return ""
-	}
-	// Backward compatibility to allow Env Override
-	// Get Env Value
+	// Check Env Override first, so it works even without a secure auth file
 	envKey := fmt.Sprintf("GDG_CONTEXTS__%s__TOKEN", strings.ToUpper(s.contextName))
 	val := os.Getenv(envKey)
 	if val != "" {
 		return val
+	}
+
+	secureAuth := s.getSecureAuth()
+	if secureAuth == nil {
+		return ""
 	}
 
 	return secureAuth.Token

--- a/internal/config/grafana_config_test.go
+++ b/internal/config/grafana_config_test.go
@@ -12,6 +12,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEnvOverrideWithoutSecureFile verifies that environment variable overrides
+// for TOKEN and PASSWORD work even when no secure auth file exists.
+func TestEnvOverrideWithoutSecureFile(t *testing.T) {
+	// Create a config with a context name that has no corresponding secure auth file
+	config := domain.NewGrafanaConfig("nosuchcontext")
+	config.OutputPath = t.TempDir()
+
+	// Set env vars for this context
+	t.Setenv("GDG_CONTEXTS__NOSUCHCONTEXT__TOKEN", "my-token-from-env")
+	t.Setenv("GDG_CONTEXTS__NOSUCHCONTEXT__PASSWORD", "my-password-from-env")
+
+	assert.Equal(t, "my-token-from-env", config.GetAPIToken())
+	assert.Equal(t, "my-password-from-env", config.GetPassword())
+}
+
 func TestGrafanaConfig(t *testing.T) {
 	config := domain.NewGrafanaConfig("testing")
 	config.URL = "  http://localhost  "


### PR DESCRIPTION
After upgrading to v0.9.1, any CI/CD pipeline that sets credentials via environment variables (e.g. GDG_CONTEXTS__MYCONTEXT__TOKEN) and does not have a secure auth file gets a 401 from Grafana.

 The error looks like this:

```
 WRN importer.yml as default config is deprecated. Please use gdg.yml moving forward.
 ERR domain/grafana_config.go:141 unable to find secure file exports/secure/auth_grafanacloud
 ERR domain/grafana_config.go:141 unable to find secure file exports/secure/auth_grafanacloud
 Failed to retrieve dashboards[GET /search][401] searchUnauthorized {"message":"Invalid username or password"}
```

 The env var GDG_CONTEXTS__GRAFANACLOUD__TOKEN is set correctly but never checked.
 
This change request moves the env var check before the `getSecureAuth()` call in both `GetAPIToken()` and `GetPassword()`. This preserves the intended (I think?) priority (env var > secure file > empty string) while removing the accidental requirement that the secure file must exist for env vars to work.