### PR TITLE
test: guard slice indexing with non-empty checks

### DIFF
--- a/test/alerting_policies_test.go
+++ b/test/alerting_policies_test.go
@@ -51,8 +51,10 @@ func TestPoliciesCrud(t *testing.T) {
 		return item.Receiver == "slack" && item.Continue
 	})
 	assert.NotNil(t, route)
-	assert.Equal(t, len(route.ObjectMatchers[0]), 3)
-	assert.Equal(t, route.ObjectMatchers[0][2], "23")
+	if assert.NotEmpty(t, route.ObjectMatchers) {
+		assert.Equal(t, len(route.ObjectMatchers[0]), 3)
+		assert.Equal(t, route.ObjectMatchers[0][2], "23")
+	}
 
 	policies, err = apiClient.ListAlertNotifications()
 	assert.NoError(t, err)

--- a/test/alerting_templates_test.go
+++ b/test/alerting_templates_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"context"
+	"log"
 	"log/slog"
 	"os"
 	"slices"
@@ -116,7 +117,9 @@ func TestTemplatesFilterTest(t *testing.T) {
 				regex:    "^test_tpl1$",
 				expected: 1,
 				validate: func(t *testing.T, list []*models.NotificationTemplate) {
-					assert.Equal(t, "test_tpl1", list[0].Name)
+					if assert.NotEmpty(t, list) {
+						assert.Equal(t, "test_tpl1", list[0].Name)
+					}
 				},
 			},
 			{
@@ -124,6 +127,10 @@ func TestTemplatesFilterTest(t *testing.T) {
 				regex:    "_test$",
 				expected: 1,
 				validate: func(t *testing.T, list []*models.NotificationTemplate) {
+					if len(list) == 0 {
+						t.Error("empty list provided")
+						return
+					}
 					assert.Equal(t, "tpl2_test", list[0].Name)
 				},
 			},
@@ -146,7 +153,9 @@ func TestTemplatesFilterTest(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				filter := api.NewAlertTemplatesFilter(tc.regex)
+				log.Printf("FILTER: %v", filter)
 				list, listErr := apiClient.ListAlertTemplates(filter)
+				log.Printf("LIST: %v", list)
 				assert.NoError(t, listErr)
 				assert.Equal(t, tc.expected, len(list))
 				if tc.validate != nil {
@@ -159,19 +168,22 @@ func TestTemplatesFilterTest(t *testing.T) {
 	t.Run("Clear respects filter", func(t *testing.T) {
 		cleared, clearErr := apiClient.ClearAlertTemplates(api.NewAlertTemplatesFilter("^test_tpl1$"))
 		assert.NoError(t, clearErr)
-		assert.Equal(t, 1, len(cleared))
-		assert.Equal(t, "test_tpl1", cleared[0])
+		if assert.NotEmpty(t, cleared) {
+			assert.Equal(t, "test_tpl1", cleared[0])
+		}
 
 		remaining, listErr := apiClient.ListAlertTemplates(api.NewAlertTemplatesFilter(""))
 		assert.NoError(t, listErr)
-		assert.Equal(t, 1, len(remaining))
-		assert.Equal(t, "tpl2_test", remaining[0].Name)
+		if assert.NotEmpty(t, remaining) {
+			assert.Equal(t, "tpl2_test", remaining[0].Name)
+		}
 
 		// Restore the cleared template so later sub-tests see both templates again.
 		restored, uploadErr := apiClient.UploadAlertTemplates(api.NewAlertTemplatesFilter("^test_tpl1$"))
 		assert.NoError(t, uploadErr)
-		assert.Equal(t, 1, len(restored))
-		assert.Equal(t, "test_tpl1", restored[0])
+		if assert.NotEmpty(t, restored) {
+			assert.Equal(t, "test_tpl1", restored[0])
+		}
 	})
 
 	t.Run("Upload respects filter", func(t *testing.T) {
@@ -181,13 +193,15 @@ func TestTemplatesFilterTest(t *testing.T) {
 
 		uploaded, uploadErr := apiClient.UploadAlertTemplates(api.NewAlertTemplatesFilter("_test$"))
 		assert.NoError(t, uploadErr)
-		assert.Equal(t, 1, len(uploaded))
-		assert.Equal(t, "tpl2_test", uploaded[0])
+		if assert.NotEmpty(t, uploaded) {
+			assert.Equal(t, "tpl2_test", uploaded[0])
+		}
 
 		afterUpload, listErr := apiClient.ListAlertTemplates(api.NewAlertTemplatesFilter(""))
 		assert.NoError(t, listErr)
-		assert.Equal(t, 1, len(afterUpload))
-		assert.Equal(t, "tpl2_test", afterUpload[0].Name)
+		if assert.NotEmpty(t, afterUpload) {
+			assert.Equal(t, "tpl2_test", afterUpload[0].Name)
+		}
 
 		// Restore full fixture set for the remaining sub-tests.
 		restored, uploadErr := apiClient.UploadAlertTemplates(api.NewAlertTemplatesFilter(""))

--- a/test/alerting_templates_test.go
+++ b/test/alerting_templates_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bytes"
 	"context"
-	"log"
 	"log/slog"
 	"os"
 	"slices"
@@ -153,9 +152,7 @@ func TestTemplatesFilterTest(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				filter := api.NewAlertTemplatesFilter(tc.regex)
-				log.Printf("FILTER: %v", filter)
 				list, listErr := apiClient.ListAlertTemplates(filter)
-				log.Printf("LIST: %v", list)
 				assert.NoError(t, listErr)
 				assert.Equal(t, tc.expected, len(list))
 				if tc.validate != nil {
@@ -169,12 +166,14 @@ func TestTemplatesFilterTest(t *testing.T) {
 		cleared, clearErr := apiClient.ClearAlertTemplates(api.NewAlertTemplatesFilter("^test_tpl1$"))
 		assert.NoError(t, clearErr)
 		if assert.NotEmpty(t, cleared) {
+			assert.Equal(t, 1, len(cleared))
 			assert.Equal(t, "test_tpl1", cleared[0])
 		}
 
 		remaining, listErr := apiClient.ListAlertTemplates(api.NewAlertTemplatesFilter(""))
 		assert.NoError(t, listErr)
 		if assert.NotEmpty(t, remaining) {
+			assert.Equal(t, 1, len(remaining))
 			assert.Equal(t, "tpl2_test", remaining[0].Name)
 		}
 
@@ -182,6 +181,7 @@ func TestTemplatesFilterTest(t *testing.T) {
 		restored, uploadErr := apiClient.UploadAlertTemplates(api.NewAlertTemplatesFilter("^test_tpl1$"))
 		assert.NoError(t, uploadErr)
 		if assert.NotEmpty(t, restored) {
+			assert.Equal(t, 1, len(restored))
 			assert.Equal(t, "test_tpl1", restored[0])
 		}
 	})
@@ -194,12 +194,14 @@ func TestTemplatesFilterTest(t *testing.T) {
 		uploaded, uploadErr := apiClient.UploadAlertTemplates(api.NewAlertTemplatesFilter("_test$"))
 		assert.NoError(t, uploadErr)
 		if assert.NotEmpty(t, uploaded) {
+			assert.Equal(t, 1, len(uploaded))
 			assert.Equal(t, "tpl2_test", uploaded[0])
 		}
 
 		afterUpload, listErr := apiClient.ListAlertTemplates(api.NewAlertTemplatesFilter(""))
 		assert.NoError(t, listErr)
 		if assert.NotEmpty(t, afterUpload) {
+			assert.Equal(t, 1, len(afterUpload))
 			assert.Equal(t, "tpl2_test", afterUpload[0].Name)
 		}
 

--- a/test/alerting_timings_test.go
+++ b/test/alerting_timings_test.go
@@ -50,33 +50,34 @@ func TestAlertingTimingsCrud(t *testing.T) {
 	timingsList, err = apiClient.ListAlertTimings()
 	assert.NoError(err)
 
-	assert.Equal(len(timingsList), 1)
-	timingItem := timingsList[0]
-	assert.Equal(timingItem.Name, "after-hours")
-	assert.Equal(len(timingItem.TimeIntervals), 2)
-	timedInterval := lo.FindOrElse(timingItem.TimeIntervals, nil, func(item *models.TimeIntervalItem) bool {
-		return item.Location == "America/New_York"
-	})
-	assert.NotEmpty(timedInterval)
+	if assert.NotEmpty(timingsList) {
+		timingItem := timingsList[0]
+		assert.Equal(timingItem.Name, "after-hours")
+		assert.Equal(len(timingItem.TimeIntervals), 2)
+		timedInterval := lo.FindOrElse(timingItem.TimeIntervals, nil, func(item *models.TimeIntervalItem) bool {
+			return item.Location == "America/New_York"
+		})
+		assert.NotEmpty(timedInterval)
 
-	expected := models.TimeIntervalItem{
-		Location:    "America/New_York",
-		DaysOfMonth: []string{"7:31"},
-		Months:      []string{"1:11"},
-		Weekdays:    []string{"monday", "tuesday", "wednesday", "thursday", "friday"},
-		Years:       []string{"2021:2031"},
-		Times: []*models.TimeIntervalTimeRange{
-			{
-				EndTime:   "23:59",
-				StartTime: "17:00",
+		expected := models.TimeIntervalItem{
+			Location:    "America/New_York",
+			DaysOfMonth: []string{"7:31"},
+			Months:      []string{"1:11"},
+			Weekdays:    []string{"monday", "tuesday", "wednesday", "thursday", "friday"},
+			Years:       []string{"2021:2031"},
+			Times: []*models.TimeIntervalTimeRange{
+				{
+					EndTime:   "23:59",
+					StartTime: "17:00",
+				},
+				{
+					EndTime:   "09:00",
+					StartTime: "01:00",
+				},
 			},
-			{
-				EndTime:   "09:00",
-				StartTime: "01:00",
-			},
-		},
+		}
+		assert.True(diffStruct(timedInterval, &expected))
 	}
-	assert.True(diffStruct(timedInterval, &expected))
 
 	_, err = apiClient.DownloadAlertTimings()
 	assert.NoError(err)

--- a/test/alerting_timings_test.go
+++ b/test/alerting_timings_test.go
@@ -51,6 +51,7 @@ func TestAlertingTimingsCrud(t *testing.T) {
 	assert.NoError(err)
 
 	if assert.NotEmpty(timingsList) {
+		assert.Equal(1, len(timingsList))
 		timingItem := timingsList[0]
 		assert.Equal(timingItem.Name, "after-hours")
 		assert.Equal(len(timingItem.TimeIntervals), 2)

--- a/test/dashboard_integration_test.go
+++ b/test/dashboard_integration_test.go
@@ -612,8 +612,9 @@ func validateOtherBoard(t *testing.T, board *customModels.DashboardV2Gdg) {
 
 func validateGeneralBoard(t *testing.T, board *customModels.DashboardV2Gdg) {
 	assert.Equal(t, board.Resource.Spec.Title, "Individual Flows")
-	assert.Equal(t, len(board.Resource.Spec.Tags), 1)
-	assert.Equal(t, board.Resource.Spec.Tags[0], "netsage")
+	if assert.NotEmpty(t, board.Resource.Spec.Tags) {
+		assert.Equal(t, board.Resource.Spec.Tags[0], "netsage")
+	}
 	assert.Equal(t, board.NestedPath, "General")
 }
 

--- a/test/dashboard_integration_test.go
+++ b/test/dashboard_integration_test.go
@@ -613,6 +613,7 @@ func validateOtherBoard(t *testing.T, board *customModels.DashboardV2Gdg) {
 func validateGeneralBoard(t *testing.T, board *customModels.DashboardV2Gdg) {
 	assert.Equal(t, board.Resource.Spec.Title, "Individual Flows")
 	if assert.NotEmpty(t, board.Resource.Spec.Tags) {
+		assert.Equal(t, 1, len(board.Resource.Spec.Tags))
 		assert.Equal(t, board.Resource.Spec.Tags[0], "netsage")
 	}
 	assert.Equal(t, board.NestedPath, "General")

--- a/test/dashboard_integration_v2_test.go
+++ b/test/dashboard_integration_v2_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/esnet/gdg/internal/adapter/filters/v2"
+	v2 "github.com/esnet/gdg/internal/adapter/filters/v2"
 	"github.com/esnet/gdg/internal/adapter/grafana/api"
 	customModels "github.com/esnet/gdg/internal/domain"
 	"github.com/esnet/gdg/pkg/test_tooling/common"
@@ -500,8 +500,9 @@ func validateOtherBoardV2(t *testing.T, board *customModels.DashboardV2Gdg) {
 
 func validateGeneralBoardV2(t *testing.T, board *customModels.DashboardV2Gdg) {
 	assert.Equal(t, board.Resource.Spec.Title, "Individual Flows")
-	assert.Equal(t, len(board.Resource.Spec.Tags), 1)
-	assert.Equal(t, board.Resource.Spec.Tags[0], "netsage")
+	if assert.NotEmpty(t, board.Resource.Spec.Tags) {
+		assert.Equal(t, board.Resource.Spec.Tags[0], "netsage")
+	}
 	assert.Equal(t, board.NestedPath, "General")
 }
 

--- a/test/dashboard_permissions_test.go
+++ b/test/dashboard_permissions_test.go
@@ -88,7 +88,9 @@ func TestDashboardPermissionsCrud(t *testing.T) {
 		assert.True(t, bobGone, "bob's permission should be cleared")
 		assert.True(t, musiciansGone, "musicians team permission should be cleared")
 	} else {
-		assert.Equal(t, 0, len(currentPerms[0].Permissions))
+		if assert.NotEmpty(t, currentPerms) {
+			assert.Equal(t, 0, len(currentPerms[0].Permissions))
+		}
 	}
 	addPerms, err := apiClient.UploadDashboardPermissions(dashFilter)
 	assert.NoError(t, err)

--- a/test/libraryelements_integration_test.go
+++ b/test/libraryelements_integration_test.go
@@ -114,6 +114,7 @@ func TestLibraryElementsCRUD(t *testing.T) {
 		connections := apiClient.ListLibraryElementsConnections(filtersEntity, "T47RSwQnz")
 		if isV13() {
 			if assert.NotEmpty(t, connections) {
+				assert.Equal(t, 1, len(connections))
 				connection := connections[0]
 				assert.Equal(t, connection.Meta.FolderTitle, "n+_=23r")
 				assert.True(t, len(connection.Meta.FolderUID) > 0)

--- a/test/libraryelements_integration_test.go
+++ b/test/libraryelements_integration_test.go
@@ -113,15 +113,16 @@ func TestLibraryElementsCRUD(t *testing.T) {
 		// On v12 that dashboard is skipped, so no connection exists.
 		connections := apiClient.ListLibraryElementsConnections(filtersEntity, "T47RSwQnz")
 		if isV13() {
-			assert.Equal(t, 1, len(connections))
-			connection := connections[0]
-			assert.Equal(t, connection.Meta.FolderTitle, "n+_=23r")
-			assert.True(t, len(connection.Meta.FolderUID) > 0)
-			assert.Equal(t, connection.Meta.Slug, "dashboard-makeover-challenge")
-			assert.Equal(t, connection.Dashboard.(map[string]any)["uid"].(string), "F3eInwQ7z")
-			assert.Equal(t, connection.Dashboard.(map[string]any)["title"].(string), "Dashboard Makeover Challenge")
+			if assert.NotEmpty(t, connections) {
+				connection := connections[0]
+				assert.Equal(t, connection.Meta.FolderTitle, "n+_=23r")
+				assert.True(t, len(connection.Meta.FolderUID) > 0)
+				assert.Equal(t, connection.Meta.Slug, "dashboard-makeover-challenge")
+				assert.Equal(t, connection.Dashboard.(map[string]any)["uid"].(string), "F3eInwQ7z")
+				assert.Equal(t, connection.Dashboard.(map[string]any)["title"].(string), "Dashboard Makeover Challenge")
+			}
 		} else {
-			assert.Equal(t, 0, len(connections))
+			assert.Empty(t, connections)
 		}
 
 		// Delete All Dashboards

--- a/test/multi_org_auth_integration_test.go
+++ b/test/multi_org_auth_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/esnet/gdg/pkg/test_tooling/common"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 )
 
@@ -29,10 +30,7 @@ func pinAdminOrgContext(t *testing.T, cfg *config_domain.GDGAppConfiguration, co
 		return rebuilt, config_domain.DefaultOrganizationId
 	}
 	orgs := rebuilt.ListOrganizations(api.NewOrganizationFilter(orgName), false)
-	assert.Equal(t, 1, len(orgs), "expected exactly one org named %q", orgName)
-	if len(orgs) != 1 {
-		t.FailNow()
-	}
+	require.Equal(t, 1, len(orgs), "expected exactly one org named %q", orgName)
 	return rebuilt, orgs[0].Organization.ID
 }
 

--- a/test/organizations_integration_test.go
+++ b/test/organizations_integration_test.go
@@ -40,10 +40,11 @@ func TestOrganizationCrud(t *testing.T) {
 	}()
 	apiClient := r.ApiClient
 	orgs := apiClient.ListOrganizations(api.NewOrganizationFilter(), true)
-	assert.Equal(t, len(orgs), 1)
-	mainOrg := orgs[0]
-	assert.Equal(t, mainOrg.Organization.ID, int64(1))
-	assert.Equal(t, mainOrg.Organization.Name, "Main Org.")
+	if assert.NotEmpty(t, orgs) {
+		mainOrg := orgs[0]
+		assert.Equal(t, mainOrg.Organization.ID, int64(1))
+		assert.Equal(t, mainOrg.Organization.Name, "Main Org.")
+	}
 	newOrgs := apiClient.UploadOrganizations(api.NewOrganizationFilter())
 	assert.Equal(t, len(newOrgs), 4)
 	assert.True(t, slices.Contains(newOrgs, "DumbDumb"))
@@ -51,8 +52,9 @@ func TestOrganizationCrud(t *testing.T) {
 	assert.True(t, slices.Contains(newOrgs, "testing"))
 	// Filter Org
 	orgs = apiClient.ListOrganizations(api.NewOrganizationFilter("DumbDumb"), true)
-	assert.Equal(t, len(orgs), 1)
-	assert.Equal(t, orgs[0].Organization.Name, "DumbDumb")
+	if assert.NotEmpty(t, orgs) {
+		assert.Equal(t, orgs[0].Organization.Name, "DumbDumb")
+	}
 }
 
 func TestOrganizationUserMembership(t *testing.T) {
@@ -99,9 +101,10 @@ func TestOrganizationUserMembership(t *testing.T) {
 	assert.Nil(t, err)
 	// Start CRUD test
 	orgUsers := apiClient.ListOrgUsers(newOrg.Organization.ID)
-	assert.Equal(t, len(orgUsers), 1)
-	assert.Equal(t, orgUsers[0].Login, "admin")
-	assert.Equal(t, orgUsers[0].Role, "Admin")
+	if assert.NotEmpty(t, orgUsers) {
+		assert.Equal(t, orgUsers[0].Login, "admin")
+		assert.Equal(t, orgUsers[0].Role, "Admin")
+	}
 
 	err = apiClient.AddUserToOrg("Admin", slug.Make(newOrg.Organization.Name), orgUser.ID)
 	assert.Nil(t, err)

--- a/test/organizations_integration_test.go
+++ b/test/organizations_integration_test.go
@@ -41,6 +41,7 @@ func TestOrganizationCrud(t *testing.T) {
 	apiClient := r.ApiClient
 	orgs := apiClient.ListOrganizations(api.NewOrganizationFilter(), true)
 	if assert.NotEmpty(t, orgs) {
+		assert.Equal(t, 1, len(orgs))
 		mainOrg := orgs[0]
 		assert.Equal(t, mainOrg.Organization.ID, int64(1))
 		assert.Equal(t, mainOrg.Organization.Name, "Main Org.")
@@ -53,6 +54,7 @@ func TestOrganizationCrud(t *testing.T) {
 	// Filter Org
 	orgs = apiClient.ListOrganizations(api.NewOrganizationFilter("DumbDumb"), true)
 	if assert.NotEmpty(t, orgs) {
+		assert.Equal(t, 1, len(orgs))
 		assert.Equal(t, orgs[0].Organization.Name, "DumbDumb")
 	}
 }
@@ -102,6 +104,7 @@ func TestOrganizationUserMembership(t *testing.T) {
 	// Start CRUD test
 	orgUsers := apiClient.ListOrgUsers(newOrg.Organization.ID)
 	if assert.NotEmpty(t, orgUsers) {
+		assert.Equal(t, 1, len(orgUsers))
 		assert.Equal(t, orgUsers[0].Login, "admin")
 		assert.Equal(t, orgUsers[0].Role, "Admin")
 	}

--- a/test/service_account_test.go
+++ b/test/service_account_test.go
@@ -51,6 +51,7 @@ func TestServiceAccountCrud(t *testing.T) {
 	tokens, err := apiClient.ListServiceAccountsTokens(account.ID)
 	assert.NoError(t, err)
 	if assert.NotEmpty(t, tokens) {
+		assert.Equal(t, 1, len(tokens))
 		assert.Equal(t, tokens[0].Name, tokenName)
 	}
 	assert.NoError(t, apiClient.DeleteServiceAccount(account.ID))

--- a/test/service_account_test.go
+++ b/test/service_account_test.go
@@ -50,8 +50,9 @@ func TestServiceAccountCrud(t *testing.T) {
 	assert.True(t, strings.HasPrefix(token.Key, "glsa_"))
 	tokens, err := apiClient.ListServiceAccountsTokens(account.ID)
 	assert.NoError(t, err)
-	assert.Equal(t, len(tokens), 1)
-	assert.Equal(t, tokens[0].Name, tokenName)
+	if assert.NotEmpty(t, tokens) {
+		assert.Equal(t, tokens[0].Name, tokenName)
+	}
 	assert.NoError(t, apiClient.DeleteServiceAccount(account.ID))
 	serviceAccounts = apiClient.ListServiceAccounts()
 	assert.Equal(t, len(serviceAccounts), 1)

--- a/test/users_integration_test.go
+++ b/test/users_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana-openapi-client-go/models"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUsers(t *testing.T) {
@@ -39,26 +40,29 @@ func TestUsers(t *testing.T) {
 	apiClient := r.ApiClient
 	apiClient.DeleteAllUsers(userFilter) // clear any previous state
 	users := apiClient.ListUsers(userFilter)
-	assert.Equal(t, len(users), 1)
-	adminUser := users[0]
-	assert.Equal(t, adminUser.ID, int64(1))
-	assert.Equal(t, adminUser.Login, "admin")
-	assert.Equal(t, adminUser.IsAdmin, true)
+	if assert.NotEmpty(t, users) {
+		adminUser := users[0]
+		assert.Equal(t, adminUser.ID, int64(1))
+		assert.Equal(t, adminUser.Login, "admin")
+		assert.Equal(t, adminUser.IsAdmin, true)
+	}
 	// Only upload users matching filter
 	newUsers := apiClient.UploadUsers(api.NewUserFilter("foobar"))
-	assert.Equal(t, len(newUsers), 1)
-	assert.Equal(t, newUsers[0].Email, "s@s.com")
+	if assert.NotEmpty(t, newUsers) {
+		assert.Equal(t, newUsers[0].Email, "s@s.com")
+	}
 	// upload remaining user that do not already exist
 	newUsers = apiClient.UploadUsers(userFilter)
-	assert.Equal(t, len(newUsers), 1)
-	assert.Equal(t, newUsers[0].Email, "bob@aol.com")
+	if assert.NotEmpty(t, newUsers) {
+		assert.Equal(t, newUsers[0].Email, "bob@aol.com")
+	}
 	users = apiClient.ListUsers(userFilter)
 	assert.Equal(t, len(users), 3)
 	var user *models.UserSearchHitDTO
 	user = lo.FirstOrEmpty(lo.Filter(users, func(userItem *models.UserSearchHitDTO, index int) bool {
 		return userItem.Name == "supertux"
 	}))
-	assert.NotNil(t, user)
+	require.NotNil(t, user)
 	assert.Equal(t, user.Login, "tux")
 	assert.Equal(t, user.Email, "s@s.com")
 	assert.Equal(t, user.LastSeenAtAge, "10 years")

--- a/test/users_integration_test.go
+++ b/test/users_integration_test.go
@@ -41,6 +41,7 @@ func TestUsers(t *testing.T) {
 	apiClient.DeleteAllUsers(userFilter) // clear any previous state
 	users := apiClient.ListUsers(userFilter)
 	if assert.NotEmpty(t, users) {
+		assert.Equal(t, 1, len(users))
 		adminUser := users[0]
 		assert.Equal(t, adminUser.ID, int64(1))
 		assert.Equal(t, adminUser.Login, "admin")
@@ -49,11 +50,13 @@ func TestUsers(t *testing.T) {
 	// Only upload users matching filter
 	newUsers := apiClient.UploadUsers(api.NewUserFilter("foobar"))
 	if assert.NotEmpty(t, newUsers) {
+		assert.Equal(t, 1, len(newUsers))
 		assert.Equal(t, newUsers[0].Email, "s@s.com")
 	}
 	// upload remaining user that do not already exist
 	newUsers = apiClient.UploadUsers(userFilter)
 	if assert.NotEmpty(t, newUsers) {
+		assert.Equal(t, 1, len(newUsers))
 		assert.Equal(t, newUsers[0].Email, "bob@aol.com")
 	}
 	users = apiClient.ListUsers(userFilter)


### PR DESCRIPTION
Wrap direct slice indexing (e.g., `s[0]`) inside conditional non-empty assertions across integration tests to prevent index out-of-bounds panics when slices are empty.